### PR TITLE
Remove erroneous period from several Extractors

### DIFF
--- a/Cisco-ASA-Extractor.json
+++ b/Cisco-ASA-Extractor.json
@@ -11,7 +11,7 @@
       ],
       "cursor_strategy": "copy",
       "extractor_config": {
-        "regex_value": "^<(\\d.+)>"
+        "regex_value": "^<(\\d+)>"
       },
       "extractor_type": "regex",
       "order": 0,
@@ -30,7 +30,7 @@
       ],
       "cursor_strategy": "copy",
       "extractor_config": {
-        "regex_value": "^<(\\d.+)>"
+        "regex_value": "^<(\\d+)>"
       },
       "extractor_type": "regex",
       "order": 0,
@@ -49,7 +49,7 @@
       ],
       "cursor_strategy": "copy",
       "extractor_config": {
-        "regex_value": "^<(\\d.+)>"
+        "regex_value": "^<(\\d+)>"
       },
       "extractor_type": "regex",
       "order": 1,


### PR DESCRIPTION
This period broke messages from mnemonic 106100 because it has a ">" in the middle of the message.
Fixes #2
